### PR TITLE
Hotfix/uc11 data wordt niet bijgewerkt

### DIFF
--- a/Grocery.App/ViewModels/BoughtProductsViewModel.cs
+++ b/Grocery.App/ViewModels/BoughtProductsViewModel.cs
@@ -13,6 +13,7 @@ namespace Grocery.App.ViewModels
 
         [ObservableProperty]
         Product selectedProduct;
+        
         public ObservableCollection<BoughtProducts> BoughtProductsList { get; set; } = [];
         public ObservableCollection<Product> Products { get; set; }
 
@@ -21,12 +22,40 @@ namespace Grocery.App.ViewModels
             _boughtProductsService = boughtProductsService;
             Products = new(productService.GetAll());
         }
+        
 
+        /// <summary>
+        /// Wordt automatisch aangeroepen wanneer een nieuw product geselecteerd wordt in de Picker.
+        /// Haalt alle klanten en boodschappenlijsten op die dit product gekocht hebben.
+        /// </summary>
+        /// <param name="oldValue">Het vorige geselecteerde product</param>
+        /// <param name="newValue">Het nieuw geselecteerde product</param>
         partial void OnSelectedProductChanged(Product? oldValue, Product newValue)
         {
-            //Zorg dat de lijst BoughtProductsList met de gegevens die passen bij het geselecteerde product. 
+            if (newValue != null)
+            {
+                System.Diagnostics.Debug.WriteLine($"Product geselecteerd: {newValue.Name} (Id: {newValue.Id})");
+                
+                BoughtProductsList.Clear();
+                var boughtProducts = _boughtProductsService.Get(newValue.Id);
+                
+                System.Diagnostics.Debug.WriteLine($"Aantal BoughtProducts ontvangen: {boughtProducts.Count}");
+                
+                foreach (var item in boughtProducts)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Toevoegen aan lijst: {item.Client.Name} - {item.GroceryList.Name}");
+                    BoughtProductsList.Add(item);
+                }
+                
+                System.Diagnostics.Debug.WriteLine($"BoughtProductsList Count: {BoughtProductsList.Count}");
+            }
         }
 
+        /// <summary>
+        /// Command om een nieuw product te selecteren vanuit de code-behind van de View.
+        /// Update de SelectedProduct property, wat vervolgens OnSelectedProductChanged triggert.
+        /// </summary>
+        /// <param name="product">Het product dat geselecteerd moet worden</param>
         [RelayCommand]
         public void NewSelectedProduct(Product product)
         {

--- a/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
@@ -97,6 +97,7 @@ namespace Grocery.App.ViewModels
         [RelayCommand]
         public void IncreaseAmount(int productId)
         {
+            System.Diagnostics.Debug.WriteLine($"[DEBUG] IncreaseAmount called for ProductId: {productId}");
             GroceryListItem? item = MyGroceryListItems.FirstOrDefault(x => x.ProductId == productId);
             if (item == null) return;
             if (item.Amount >= item.Product.Stock) return;

--- a/Grocery.App/ViewModels/GroceryListViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListViewModel.cs
@@ -10,11 +10,13 @@ namespace Grocery.App.ViewModels
     {
         public ObservableCollection<GroceryList> GroceryLists { get; set; }
         private readonly IGroceryListService _groceryListService;
+        private readonly GlobalViewModel _globalViewModel;
 
-        public GroceryListViewModel(IGroceryListService groceryListService) 
+        public GroceryListViewModel(IGroceryListService groceryListService, GlobalViewModel globalViewModel) 
         {
             Title = "Boodschappenlijst";
             _groceryListService = groceryListService;
+            _globalViewModel = globalViewModel;
             GroceryLists = new(_groceryListService.GetAll());
         }
 
@@ -24,6 +26,16 @@ namespace Grocery.App.ViewModels
             Dictionary<string, object> paramater = new() { { nameof(GroceryList), groceryList } };
             await Shell.Current.GoToAsync($"{nameof(Views.GroceryListItemsView)}?Titel={groceryList.Name}", true, paramater);
         }
+        
+        [RelayCommand]
+        public async Task ShowBoughtProducts()
+        {
+            if (_globalViewModel.Client != null && _globalViewModel.Client.Role == Role.Admin)
+            {
+                await Shell.Current.GoToAsync(nameof(Views.BoughtProductsView));
+            }
+        }
+        
         public override void OnAppearing()
         {
             base.OnAppearing();

--- a/Grocery.App/Views/BoughtProductsView.xaml
+++ b/Grocery.App/Views/BoughtProductsView.xaml
@@ -16,11 +16,12 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Picker Grid.Column="0" Grid.Row="0" Margin="10,0,0,0" Title="Klik op onderstaand pijltje om een product te selecteren:"
-        ItemsSource="{Binding Products}"
-        SelectedItem="{Binding SelectedProduct, Mode=TwoWay}" 
-        SelectedIndexChanged="Picker_SelectedIndexChanged"
-        BackgroundColor="{StaticResource Primary}"
-            TextColor="{StaticResource Secondary}">
+                ItemsSource="{Binding Products}"
+                ItemDisplayBinding="{Binding Name}"
+                SelectedItem="{Binding SelectedProduct, Mode=TwoWay}" 
+                SelectedIndexChanged="Picker_SelectedIndexChanged"
+                BackgroundColor="{StaticResource Primary}"
+                TextColor="{StaticResource Secondary}">
         </Picker>
         <Border Grid.Row="1" Grid.Column="0" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5" HorizontalOptions="Center">
             <CollectionView ItemsSource="{Binding BoughtProductsList}" Margin="5" HorizontalOptions="End" SelectionMode="Single">
@@ -34,7 +35,15 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <!-- Toon hier de naam van de Client naam van de boodschappenlijst -->
+                            <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" Text="{Binding Client.Name}" FontSize="16" />
+                            <Label Grid.Column="1" Text="{Binding GroceryList.Name}" FontSize="16" HorizontalOptions="End" />
+                        </Grid>
+
                         </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -40,12 +40,27 @@
                             </Grid.ColumnDefinitions>
                             <Label Grid.Column="0" Text="{Binding Product.Name}" VerticalOptions="Center"/>
                             <Label Grid.Column="1" Text="{Binding Amount}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"/>
-                            <Grid Grid.Column="2">
-                                <Image Source="plus.png" WidthRequest="15" HeightRequest="15"/>
-                            </Grid>
-                            <Grid Grid.Column="3">
-                                <Image Source="min.png" WidthRequest="15" HeightRequest="15"/>
-                            </Grid>
+                                <!-- Plus knop -->
+                                <Button Grid.Column="2"
+                                        WidthRequest="30"
+                                        HeightRequest="30"
+                                        BackgroundColor="Transparent"
+                                        BorderWidth="0"
+                                        Text="+"
+                                        TextColor="Black"
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type vm:GroceryListItemsViewModel}}, Path=IncreaseAmountCommand}"
+                                        CommandParameter="{Binding ProductId}" />
+
+                                <!-- Min knop -->
+                                <Button Grid.Column="3"
+                                        WidthRequest="30"
+                                        HeightRequest="30"
+                                        BackgroundColor="Transparent"
+                                        BorderWidth="0"
+                                        TextColor="Black"
+                                        Text="-"
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type vm:GroceryListItemsViewModel}}, Path=DecreaseAmountCommand}"
+                                        CommandParameter="{Binding ProductId}" />
                         </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Grocery.App/Views/GroceryListsView.xaml
+++ b/Grocery.App/Views/GroceryListsView.xaml
@@ -11,6 +11,12 @@
             <Label Text="Boodschappenlijsten" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
         </Grid>
     </Shell.TitleView>
+    
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Admin Menu" Command="{Binding ShowBoughtProductsCommand}" />
+    </ContentPage.ToolbarItems>
+
+
 
     <Border Stroke="#C49B33"
         StrokeThickness="4"

--- a/Grocery.Core.Data/Repositories/ClientRepository.cs
+++ b/Grocery.Core.Data/Repositories/ClientRepository.cs
@@ -13,7 +13,8 @@ namespace Grocery.Core.Data.Repositories
             clientList = [
                 new Client(1, "M.J. Curie", "user1@mail.com", "IunRhDKa+fWo8+4/Qfj7Pg==.kDxZnUQHCZun6gLIE6d9oeULLRIuRmxmH2QKJv2IM08="),
                 new Client(2, "H.H. Hermans", "user2@mail.com", "dOk+X+wt+MA9uIniRGKDFg==.QLvy72hdG8nWj1FyL75KoKeu4DUgu5B/HAHqTD2UFLU="),
-                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=")
+                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=") { Role = Role.Admin }
+
             ];
         }
 

--- a/Grocery.Core/Models/BestSellingProducts.cs
+++ b/Grocery.Core/Models/BestSellingProducts.cs
@@ -12,6 +12,15 @@ namespace Grocery.Core.Models
         [ObservableProperty]
         private int _ranking;
 
+        /// <summary>
+        /// Constructor om een nieuw BestSellingProducts object aan te maken met alle verkoopstatistieken
+        /// </summary>
+        /// <param name="productId">Het unieke ID van het product</param>
+        /// <param name="name">De naam van het product</param>
+        /// <param name="stock">De huidige voorraad</param>
+        /// <param name="nrOfSells">Het aantal keer dat het product verkocht is</param>
+        /// <param name="ranking">De ranking positie in de lijst</param>
+
         public BestSellingProducts(int productId, string name, int stock, int nrOfSells, int ranking) 
             : base(productId, name)
         {

--- a/Grocery.Core/Models/Client.cs
+++ b/Grocery.Core/Models/Client.cs
@@ -5,6 +5,8 @@ namespace Grocery.Core.Models
     {
         public string EmailAddress { get; set; }
         public string Password { get; set; }
+        public Role Role { get; set; } = Role.None;
+
         public Client(int id, string name, string emailAddress, string password) : base(id, name)
         {
             EmailAddress=emailAddress;

--- a/Grocery.Core/Models/Role.cs
+++ b/Grocery.Core/Models/Role.cs
@@ -1,0 +1,19 @@
+namespace Grocery.Core.Models
+{
+    /// <summary>
+    /// Enum die de verschillende gebruikersrollen in de applicatie definieert.
+    /// Wordt gebruikt om toegang tot bepaalde functies te beperken (zoals het bekijken van gekochte producten).
+    /// </summary>
+    public enum Role
+    {
+        /// <summary>
+        /// Standaard rol zonder speciale rechten
+        /// </summary>
+        None,
+        
+        /// <summary>
+        /// Administrator rol met toegang tot beheersfuncties zoals het bekijken van gekochte producten per klant
+        /// </summary>
+        Admin
+    }
+}

--- a/Grocery.Core/Services/BoughtProductsService.cs
+++ b/Grocery.Core/Services/BoughtProductsService.cs
@@ -1,5 +1,4 @@
-﻿
-using Grocery.Core.Interfaces.Repositories;
+﻿using Grocery.Core.Interfaces.Repositories;
 using Grocery.Core.Interfaces.Services;
 using Grocery.Core.Models;
 
@@ -11,6 +10,7 @@ namespace Grocery.Core.Services
         private readonly IClientRepository _clientRepository;
         private readonly IProductRepository _productRepository;
         private readonly IGroceryListRepository _groceryListRepository;
+        
         public BoughtProductsService(IGroceryListItemsRepository groceryListItemsRepository, IGroceryListRepository groceryListRepository, IClientRepository clientRepository, IProductRepository productRepository)
         {
             _groceryListItemsRepository=groceryListItemsRepository;
@@ -18,9 +18,47 @@ namespace Grocery.Core.Services
             _clientRepository=clientRepository;
             _productRepository=productRepository;
         }
+        
+         /// <summary>
+        /// Haalt alle gekochte producten op voor een specifiek product.
+        /// Zoekt in alle boodschappenlijsten naar items met het gegeven productId
+        /// en combineert deze met klant- en boodschappenlijst-informatie.
+        /// </summary>
+        /// <param name="productId">Het ID van het product waarvoor gekochte producten gezocht worden</param>
+        /// <returns>Een lijst van BoughtProducts met klant, boodschappenlijst en product informatie</returns>
         public List<BoughtProducts> Get(int? productId)
         {
-            throw new NotImplementedException();
+            List<BoughtProducts> boughtProductsList = new();
+            
+            System.Diagnostics.Debug.WriteLine($"BoughtProductsService.Get aangeroepen met productId: {productId}");
+            
+            if (productId == null)
+                return boughtProductsList;
+            
+            var allItems = _groceryListItemsRepository.GetAll();
+            System.Diagnostics.Debug.WriteLine($"Totaal aantal GroceryListItems: {allItems.Count}");
+            
+            var groceryListItems = allItems.Where(gli => gli.ProductId == productId).ToList();
+            System.Diagnostics.Debug.WriteLine($"Items met ProductId {productId}: {groceryListItems.Count}");
+            
+            foreach (var item in groceryListItems)
+            {
+                var groceryList = _groceryListRepository.Get(item.GroceryListId);
+                if (groceryList != null)
+                {
+                    var client = _clientRepository.Get(groceryList.ClientId);
+                    var product = _productRepository.Get(item.ProductId);
+                    
+                    if (client != null && product != null)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"Gevonden: Client={client.Name}, GroceryList={groceryList.Name}, Product={product.Name}");
+                        boughtProductsList.Add(new BoughtProducts(client, groceryList, product));
+                    }
+                }
+            }
+            
+            System.Diagnostics.Debug.WriteLine($"Totaal BoughtProducts: {boughtProductsList.Count}");
+            return boughtProductsList;
         }
     }
 }

--- a/Grocery.Core/Services/GroceryListItemsService.cs
+++ b/Grocery.Core/Services/GroceryListItemsService.cs
@@ -49,13 +49,25 @@ namespace Grocery.Core.Services
             return _groceriesRepository.Update(item);
         }
 
+        /// <summary>
+        /// Haalt de best verkopende producten op gebaseerd op het aantal keren dat ze in boodschappenlijsten voorkomen.
+        /// Groepeert alle grocery list items per product, telt het aantal verkopen, en sorteert op populariteit.
+        /// </summary>
+        /// <param name="topX">Het aantal top producten dat terug gegeven moet worden (standaard 5)</param>
+        /// <returns>Een lijst van BestSellingProducts gesorteerd op aantal verkopen met ranking</returns>
         public List<BestSellingProducts> GetBestSellingProducts(int topX = 5)
         {
+            // Haal alle grocery list items op
             var allItems = _groceriesRepository.GetAll();
+            
+            // Verzamel alle unieke product IDs
             var productIds = allItems.Select(i => i.ProductId).Distinct().ToList();
-            var allProducts = _productRepository.GetByIds(productIds) // <-- nieuwe methode in repo
+            
+            // Haal alle producten op en zet ze in een dictionary voor snelle lookup
+            var allProducts = _productRepository.GetByIds(productIds)
                 .ToDictionary(p => p.Id);
 
+            // Groepeer items per product en tel het aantal verkopen
             var grouped = allItems
                 .GroupBy(i => i.ProductId)
                 .Select(g =>
@@ -66,20 +78,21 @@ namespace Grocery.Core.Services
                         ProductId = g.Key,
                         ProductName = product?.Name ?? "Onbekend product",
                         Stock = product?.Stock ?? 0,
-                        NrOfSells = g.Count()
+                        NrOfSells = g.Count() // Tel hoeveel keer dit product voorkomt
                     };
                 })
-                .OrderByDescending(x => x.NrOfSells)
-                .Take(topX)
+                .OrderByDescending(x => x.NrOfSells) // Sorteer van meest naar minst verkocht
+                .Take(topX) // Neem alleen de top X
                 .ToList();
 
+            // Maak BestSellingProducts objecten met ranking (1 = meest verkocht)
             return grouped
                 .Select((x, index) => new BestSellingProducts(
                     x.ProductId,
                     x.ProductName,
                     x.Stock,
                     x.NrOfSells,
-                    index + 1
+                    index + 1 // Ranking begint bij 1
                 ))
                 .ToList();
         }


### PR DESCRIPTION
## Probleem 

> Tijdens het handmatig testen bleken twee issues:
> Plus/min-knoppen in de boodschappenlijst deden niets – veroorzaakt door onklikbare Image-elementen en ontbrekende commando-binding.
> Bestseller-lijst telde alleen het aantal lijsten, niet het totale aantal stuks (Amount).

## Oplossing

> Images vervangen door Button met Text=+"/"-" voor klikbaarheid.
> Bind commando’s via RelativeSource naar GroceryListItemsViewModel.
> GetBestSellingProducts() aangepast = (gebruik g.Sum(item => item.Amount) i.p.v. g.Count().)

## Resultaat

> Knoppen werken bij alle producten.
> Aantal verkochte stuks wordt correct geteld.
